### PR TITLE
Add query options to findOne operation

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -33,7 +33,15 @@ exports.plugin = {
           }
 
           case 'findone': {
-            result = await db.collection(collection).findOne({ [queryParam]: new ObjectId(request.params[queryParam]) })
+            const queryRequest = buildQueryRequest(request.query)
+
+            if (queryRequest.error) {
+              return Boom.badRequest('Invalid query options')
+            }
+
+            result = await db
+              .collection(collection)
+              .findOne({ [queryParam]: new ObjectId(request.params[queryParam]) }, queryRequest.options)
             break
           }
 


### PR DESCRIPTION
Right now it is not possible to use Projections when using the `findOne` operation. This PR adds the `query.options` into the operation so we may inform Mongo of what are the projections we want to get.