### PR TITLE
Set default to 0 so we can have unlimited results

### DIFF
--- a/lib/helpers/index.js
+++ b/lib/helpers/index.js
@@ -5,7 +5,7 @@ exports.buildQueryRequest = ({ skip, limit, sort, projection, find }) => {
   }
 
   try {
-    result.options.skip = Number(skip || 0)
+    result.options.skip = skip || 0
     result.options.limit = limit || 100
     if (find) result.query = JSON.parse(find)
     if (sort) result.options.sort = JSON.parse(sort)

--- a/lib/helpers/index.js
+++ b/lib/helpers/index.js
@@ -6,7 +6,7 @@ exports.buildQueryRequest = ({ skip, limit, sort, projection, find }) => {
 
   try {
     result.options.skip = Number(skip || 0)
-    result.options.limit = Number(limit || 25)
+    result.options.limit = Number(limit || 0)
     if (find) result.query = JSON.parse(find)
     if (sort) result.options.sort = JSON.parse(sort)
     if (projection) result.options.projection = JSON.parse(projection)

--- a/lib/helpers/index.js
+++ b/lib/helpers/index.js
@@ -6,7 +6,7 @@ exports.buildQueryRequest = ({ skip, limit, sort, projection, find }) => {
 
   try {
     result.options.skip = Number(skip || 0)
-    result.options.limit = Number(limit || 0)
+    result.options.limit = limit || 100
     if (find) result.query = JSON.parse(find)
     if (sort) result.options.sort = JSON.parse(sort)
     if (projection) result.options.projection = JSON.parse(projection)

--- a/test/helpers.test.js
+++ b/test/helpers.test.js
@@ -19,7 +19,7 @@ describe('mongocruise - helpers', () => {
   })
 
   it('should handle "limit" query parameter', () => {
-    const request = { limit: '5' }
+    const request = { limit: 5 }
     const result = buildQueryRequest(request)
     expect(result.options.limit).to.be.a.number().and.to.equal(5)
   })
@@ -27,7 +27,7 @@ describe('mongocruise - helpers', () => {
   it('should handle undefined "limit" query parameter', () => {
     const request = { limit: null }
     const result = buildQueryRequest(request)
-    expect(result.options.limit).to.be.a.number().and.to.equal(0)
+    expect(result.options.limit).to.be.a.number().and.to.equal(100)
   })
 
   it('should handle "sort" query parameter', () => {
@@ -51,7 +51,7 @@ describe('mongocruise - helpers', () => {
   it('builds query request correctly with valid parameters', () => {
     const params = {
       skip: '10',
-      limit: '5',
+      limit: 5,
       sort: '{"field":"asc"}',
       projection: '{"field":1}',
       find: '{"field":"value"}'

--- a/test/helpers.test.js
+++ b/test/helpers.test.js
@@ -27,7 +27,7 @@ describe('mongocruise - helpers', () => {
   it('should handle undefined "limit" query parameter', () => {
     const request = { limit: null }
     const result = buildQueryRequest(request)
-    expect(result.options.limit).to.be.a.number().and.to.equal(25)
+    expect(result.options.limit).to.be.a.number().and.to.equal(0)
   })
 
   it('should handle "sort" query parameter', () => {

--- a/test/helpers.test.js
+++ b/test/helpers.test.js
@@ -7,7 +7,7 @@ const { expect } = Code
 
 describe('mongocruise - helpers', () => {
   it('should handle "skip" query parameter', () => {
-    const request = { skip: '10' }
+    const request = { skip: 10 }
     const result = buildQueryRequest(request)
     expect(result.options.skip).to.be.a.number().and.to.equal(10)
   })
@@ -50,7 +50,7 @@ describe('mongocruise - helpers', () => {
 
   it('builds query request correctly with valid parameters', () => {
     const params = {
-      skip: '10',
+      skip: 10,
       limit: 5,
       sort: '{"field":"asc"}',
       projection: '{"field":1}',


### PR DESCRIPTION
# Description

Right now the logic on the helper is setting `limit` to a default of `25` if the there's no `limit` specified, OR, if the value of `limit = 0`. That's because the comparison `Number(limit) || 25` will always return `25` since `!!Number(0)` is `false`.

This PR is allowing users of Mongocruise to decide whether to `limit` their queries to Mongo or not, since if the limit is set to `0` in Mongo, it will return all items.
- https://www.mongodb.com/docs/manual/reference/method/cursor.limit/#zero-value

 