### PR TITLE
[PROPOSAL] - Allow Mongocruise to handle aggregation operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Mongocruise is a flexible, user-friendly plugin for the Hapi.js server framework
 
 - Easily define CRUD operations in your Hapi.js routes.
 - Flexible route parameters that leverage MongoDB's search capabilities.
-- Supports various MongoDB operations including `find`, `findOne`, `insertOne`, `updateOne`, and `deleteOne`.
+- Supports various MongoDB operations including `find`, `findOne`, `insertOne`, `updateOne`, `deleteOne`, and `aggregate` for more advanced queries.
 
 ## Installation
 
@@ -46,16 +46,38 @@ await server.register(require('mongocruise'))
 }
 ```
 
+For aggregate operations, the pipeline option must be a function that returns an array representing the aggregation pipeline:
+
+```javascript
+{
+  method: 'GET',
+  path: '/aggregatedUsers',
+  handler: {
+    mongocruise: {
+      collection: 'users',
+      operation: 'aggregate',
+      pipeline: (request) => [
+        { $match: { age: { $gte: 18 } } },
+        { $group: { _id: null, total: { $sum: 1 } } }
+      ]
+    }
+  }
+}
+```
+
 The `mongocruise` handler supports the following options:
 
 - `collection`: The MongoDB collection to use.
-- `operation`: The MongoDB operation to perform. Can be one of `find`, `findOne`, `insertOne`, `updateOne`, or `deleteOne`.
+- `operation`: The MongoDB operation to perform. Can be one of `find`, `findOne`, `insertOne`, `updateOne`, `deleteOne`, or `aggregate`.
 - `queryParam`: The parameter to use for `findOne`, `updateOne`, and `deleteOne` operations.
 - `setTimestamps`: The flag to add `createdAt` or `updatedAt` on the create and update operations.
+- `pipeline`: A function that returns an array representing the aggregation pipeline for `aggregate` operations.
 
 For `find` operations, query parameters such as `skip`, `limit`, `sort`, `projection`, and `find` can be passed directly in the request. These parameters should be in JSON format.
 
 ## Example
+
+### Simple Query Example
 
 ```javascript
 {
@@ -72,6 +94,40 @@ For `find` operations, query parameters such as `skip`, `limit`, `sort`, `projec
 ```
 
 This route configuration would use the `findOne` operation on the `users` collection, using the `_id` route parameter to find a specific user.
+
+### Aggregation Example
+
+```javascript
+{
+  method: 'GET',
+  path: '/todos',
+  handler: {
+    mongocruise: {
+      collection: 'todos',
+      operation: 'aggregate',
+      pipeline: (request) => [
+        { $match: { author: request.query.userId } },
+        { $facet: {
+            totalTodos: [{ $count: "count" }],
+            todos: [
+              { $skip: request.query.skip || 0 },
+              { $limit: request.query.limit || 10 },
+              { $project: { _id: 1, title: 1 } }
+            ]
+          }
+        },
+        { $project: {
+            totalTodos: { $arrayElemAt: ["$totalTodos.count", 0] },
+            todos: 1
+          }
+        }
+      ]
+    }
+  }
+}
+```
+
+Note that `pipeline` is a function. This is required since we need to pass down the `request` values to the pipeline to support dynamic values.
 
 ## Error Handling
 

--- a/lib/mongocruise.js
+++ b/lib/mongocruise.js
@@ -3,7 +3,7 @@ const { buildQueryRequest, getQueryParamValue } = require('./helpers')
 
 module.exports = function mongocruise(options) {
   const handler = async (request, h) => {
-    const { collection, operation, queryParam, setTimestamps = true } = options
+    const { collection, operation, queryParam, setTimestamps = true, pipeline } = options
     const { db, ObjectId } = h.mongo
     const now = new Date().getTime()
     let result
@@ -57,6 +57,25 @@ module.exports = function mongocruise(options) {
 
       case 'deleteone': {
         result = await db.collection(collection).deleteOne({ [queryParam]: new ObjectId(request.params[queryParam]) })
+        break
+      }
+
+      case 'aggregate': {
+        if (typeof pipeline !== 'function') {
+          return Boom.badRequest('Aggregation pipeline must be a function')
+        }
+
+        const pipelineToUse = pipeline(request)
+        if (!pipelineToUse || !Array.isArray(pipelineToUse)) {
+          return Boom.badRequest('Invalid aggregation pipeline')
+        }
+
+        try {
+          result = await db.collection(collection).aggregate(pipelineToUse).toArray()
+        } catch (error) {
+          return Boom.internal('MongoDB error', error)
+        }
+
         break
       }
 


### PR DESCRIPTION
# Description

Currently Mongocruise is suitable for simple CRUD operations on a MongoDB only. This means that whenever we have more than 1 query that needs to be performed whether it is to manipulate the data or return more than a single set of data in a single API call, we need to rely on Hapi's handler rendering Mongocruise unusable.

MongoDB has implemented [the Aggregation Pipeline](https://www.mongodb.com/docs/manual/core/aggregation-pipeline/) for a while now, and it suits a vast range of applications. This proposal is in place so we may allow users of the library to have more freedom, and leverage Mongo's internal capabilities a bit better.

# Motivation

What brought me to this proposal was the implementation of server-side pagination in our application. Basically, when using pagination we need to inform both the `totalCount` of items of a specific collection, as well as the paginated items according to the `skip` and `limit` values of the request. So let's assume we have a `find` route using Mongocruise before implementing pagination: 
```js
module.exports = {
  method: 'GET',
  path: '/todos',
  options: {
    id: 'findTodos',
  },
  handler: {
    mongocruise: {
       collection: 'todos',
       operation: 'find'
    }
  }
}
```

This is great for a simple `GET` request, but as data increases, we need to think of a different strategy, in this case, we're paginating the request. So as we know, to render the `todos` here we will need both the `totalCount` and the list of items per page. This means that we will need to perform the queries ourselves in the handler, which starts to bloat the code, so we go from the route above, to the 🍝 route below: 
```js
module.exports = {
  method: 'GET',
  path: '/todos',
  options: {
    id: 'findTodos'
  },
  handler: async (request, h) => {
    const { skip, limit } = request.query
    const { db } = h.mongo

    try {
      // Fetch the total count of todos
      const totalTodos = await db.collection('todos').countDocuments()

      // Fetch the paginated todos
      const todos = await db.collection('todos')
        .find()
        .skip(parseInt(skip, 10))
        .limit(parseInt(limit, 10))
        .project({ _id: 1, title: 1, completed: 1 })
        .toArray()

      // Return the result
      return {
        totalTodos,
        todos
      }
    } catch (error) {
      console.error(error)
      return h.response({ error: 'Failed to fetch todos' }).code(500)
    }
  }
}
```

Not literally a spaghetti route, but it does get bloated, and we can soon loose control of the complexity here. This is where the aggregation pipeline shines, since we can aggregate queries into a single operation, and also update the returning data anyway we would like.

# The new route

By using the new operation implemented in the proposal, we could move from a bloated route like the one above, to a more streamlined version, which follows Mongocruise pattern which you can see below: 
```js
const paginatedTodosPipeline = require('./pipeline')

module.exports = {
  method: 'GET',
  path: '/todos',
  options: {
    id: 'findTodos',
  },
  handler: {
    mongocruise: {
      collection: 'todos',
      operation: 'aggregate',
      pipeline: paginatedTodosPipeline
    }
  }
}
```

This gives us a clean pattern for route definition, and we also have freedom to update our queries and even filter out the results in any way we'd like, for example, we could `GET` all `todos` filtering by `author`: 
```js
// todos/pipeline.js
const buildPipeline = (request) => {
  const { skip, limit, author } = request.query;

  return [
    {
      $match: { author },
      $facet: {
        totalTodos: [{ $count: "count" }],
        todos: [
          { $skip: parseInt(skip, 10) },
          { $limit: parseInt(limit, 10) },
          { $project: { _id: 1, title: 1, completed: 1 } }
        ]
      }
    },
    {
      $project: {
        totalTodos: { $arrayElemAt: ["$totalTodos.count", 0] },
        todos: 1
      }
    }
  ]
}
```

In this example we are using a complex pipeline with `$facet` where we are able to run multiple pipelines at once, and return a single value.

# Error handling

I've decided to handle errors related to the structure of the `operation`, which means we deal with errors that are related to how `mongocruise` expects the payload, and leave Mongo to return the errors in case the pipeline has a wrong syntax or anything like that.

The reason for that is that I don't believe that `mongocruise` should accomodate to all possible scenarios where a pipeline may fail, and instead, we rely on Mongo's internal "knowledge" of the pipeline to return the appropriate response.

# Conclusion

I believe this can be a nice approach to leverage MongoDB to it's full potential, and bring `mongocruise` to another level in regards to where it is currently, as well as giving users more freedom to the type of operations that are made in the API level.
